### PR TITLE
[chore] Update Elasticsearch image version and adjust Pytho version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
     container_name: elasticsearch
     ports:
       - "9200:9200"


### PR DESCRIPTION
Update Elasticsearch image to version 9.0.2 and adjust Python version in CI workflow to 3.10.13