### PR TITLE
fix: Use correct health check endpoint for Qdrant v1.7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,7 +199,7 @@ jobs:
           QDRANT__SERVICE__HTTP_PORT: 6333
           QDRANT__SERVICE__GRPC_PORT: 6334
         options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:6333/health || exit 1"
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:6333/cluster || exit 1"
           --health-interval 30s
           --health-timeout 10s
           --health-retries 5
@@ -222,7 +222,7 @@ jobs:
     - name: Wait for Qdrant
       run: |
         echo "Waiting for Qdrant to be ready..."
-        timeout 120 bash -c 'until wget --quiet --tries=1 --spider http://localhost:6333/health 2>/dev/null; do 
+        timeout 120 bash -c 'until wget --quiet --tries=1 --spider http://localhost:6333/cluster 2>/dev/null; do 
           echo "Qdrant not ready yet, waiting..."; 
           sleep 5; 
         done'


### PR DESCRIPTION
The /health endpoint doesn't exist in Qdrant v1.7.4, causing container initialization to fail with 'unhealthy' status in GitHub Actions.

Changes:
- Replace /health with /cluster endpoint in health check command
- Update wait step to use /cluster endpoint for readiness check
- /cluster endpoint exists and returns proper JSON with 'ok' status

This fixes the 'One or more containers failed to start' error in vector-integration-test job.