### PR TITLE
fix: Use latest Qdrant version with correct health check endpoint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,14 +192,14 @@ jobs:
     
     services:
       qdrant:
-        image: qdrant/qdrant:v1.7.4
+        image: qdrant/qdrant:latest
         ports:
           - 6333:6333
         env:
           QDRANT__SERVICE__HTTP_PORT: 6333
           QDRANT__SERVICE__GRPC_PORT: 6334
         options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:6333/health || exit 1"
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:6333/cluster || exit 1"
           --health-interval 30s
           --health-timeout 10s
           --health-retries 5
@@ -222,7 +222,7 @@ jobs:
     - name: Wait for Qdrant
       run: |
         echo "Waiting for Qdrant to be ready..."
-        timeout 120 bash -c 'until wget --quiet --tries=1 --spider http://localhost:6333/health 2>/dev/null; do 
+        timeout 120 bash -c 'until wget --quiet --tries=1 --spider http://localhost:6333/cluster 2>/dev/null; do 
           echo "Qdrant not ready yet, waiting..."; 
           sleep 5; 
         done'


### PR DESCRIPTION
Problem: Qdrant containers fail to start in GitHub Actions because the /health endpoint doesn't exist in any Qdrant version.

Solution:
- Use qdrant/qdrant:latest (v1.14.1) - latest features and stability
- Replace /health with /cluster endpoint - works in all versions
- Both health check and integration tests work perfectly

Benefits:
- Latest Qdrant features and bug fixes
- Proper health check that actually works
- Fixes 'One or more containers failed to start' error

Tested locally: ✅ Health check ✅ Integration tests ✅ Vector operations